### PR TITLE
Exclude some stuff from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,20 @@ parallel = true
 source = io4dolfinx
 
 [html]
-directory= htmlcov
+directory = htmlcov
 
 [xml]
 output = coverage.xml
+
+[report]
+exclude_also =
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    class .*\bProtocol\):
+    @(abc\.)?abstractmethod


### PR DESCRIPTION
Functions that only include `raise NotImplementedError` should not need to be covered by the tests so just adding this to `.coveragerc` as suggested in https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion