### PR TITLE
Remove inspect hack - it doesn't work with python< 3.12

### DIFF
--- a/src/io4dolfinx/checkpointing.py
+++ b/src/io4dolfinx/checkpointing.py
@@ -442,6 +442,15 @@ def read_mesh(
         except TypeError:
             partitioner = dolfinx.cpp.mesh.create_cell_partitioner(ghost_mode)
 
+        # Should change to the commented code below when we require python
+        # minimum version to be >=3.12 see https://github.com/python/cpython/pull/116198
+        # import inspect
+        # sig = inspect.signature(dolfinx.mesh.create_cell_partitioner)
+        # part_kwargs = {}
+        # if "max_facet_to_cell_links" in list(sig.parameters.keys()):
+        #     part_kwargs["max_facet_to_cell_links"] = max_facet_to_cell_links
+        # partitioner = dolfinx.cpp.mesh.create_cell_partitioner(ghost_mode, **part_kwargs)
+
     return dolfinx.mesh.create_mesh(
         comm,
         cells=dist_in_data.cells,

--- a/src/io4dolfinx/checkpointing.py
+++ b/src/io4dolfinx/checkpointing.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import inspect
 import typing
 from pathlib import Path
 from typing import Any
@@ -436,11 +435,12 @@ def read_mesh(
             else:
                 return partition_graph
     else:
-        sig = inspect.signature(dolfinx.mesh.create_cell_partitioner)
-        part_kwargs = {}
-        if "max_facet_to_cell_links" in list(sig.parameters.keys()):
-            part_kwargs["max_facet_to_cell_links"] = max_facet_to_cell_links
-        partitioner = dolfinx.cpp.mesh.create_cell_partitioner(ghost_mode, **part_kwargs)
+        try:
+            partitioner = dolfinx.cpp.mesh.create_cell_partitioner(
+                ghost_mode, max_facet_to_cell_links=max_facet_to_cell_links
+            )
+        except TypeError:
+            partitioner = dolfinx.cpp.mesh.create_cell_partitioner(ghost_mode)
 
     return dolfinx.mesh.create_mesh(
         comm,

--- a/src/io4dolfinx/readers.py
+++ b/src/io4dolfinx/readers.py
@@ -199,6 +199,23 @@ def read_mesh_from_legacy_h5(
             partitioner=None,
         )
 
+    # Should change to the commented code below when we require python
+    # minimum version to be >=3.12 see https://github.com/python/cpython/pull/116198
+    # import inspect
+    # sig = inspect.signature(dolfinx.mesh.create_mesh)
+    # kwargs: dict[str, int] = {}
+    # if "max_facet_to_cell_links" in list(sig.parameters.keys()):
+    #     kwargs["max_facet_to_cell_links"] = max_facet_to_cell_links
+
+    # return dolfinx.mesh.create_mesh(
+    #     comm=MPI.COMM_WORLD,
+    #     cells=mesh_topology,
+    #     x=mesh_geometry,
+    #     e=domain,
+    #     partitioner=None,
+    #     **kwargs,
+    # )
+
 
 def read_function_from_legacy_h5(
     filename: pathlib.Path,

--- a/src/io4dolfinx/readers.py
+++ b/src/io4dolfinx/readers.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import inspect
 import pathlib
 import typing
 from pathlib import Path
@@ -181,19 +180,24 @@ def read_mesh_from_legacy_h5(
         shape=(mesh_geometry.shape[1],),
     )
     domain = ufl.Mesh(element)
-    sig = inspect.signature(dolfinx.mesh.create_mesh)
-    kwargs: dict[str, int] = {}
-    if "max_facet_to_cell_links" in list(sig.parameters.keys()):
-        kwargs["max_facet_to_cell_links"] = max_facet_to_cell_links
 
-    return dolfinx.mesh.create_mesh(
-        comm=MPI.COMM_WORLD,
-        cells=mesh_topology,
-        x=mesh_geometry,
-        e=domain,
-        partitioner=None,
-        **kwargs,
-    )
+    try:
+        return dolfinx.mesh.create_mesh(
+            comm=MPI.COMM_WORLD,
+            cells=mesh_topology,
+            x=mesh_geometry,
+            e=domain,
+            partitioner=None,
+            max_facet_to_cell_links=max_facet_to_cell_links,
+        )
+    except TypeError:
+        return dolfinx.mesh.create_mesh(
+            comm=MPI.COMM_WORLD,
+            cells=mesh_topology,
+            x=mesh_geometry,
+            e=domain,
+            partitioner=None,
+        )
 
 
 def read_function_from_legacy_h5(


### PR DESCRIPTION
For some reason, the `inspect.signature` doesn't work for python < 3.12. I belive it is related to the same issue here: https://github.com/python/cpython/issues/86951. 

For now lets add a try-except block, but add a comment about the issue. 

See example from the tests during conda build e.g here: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1465766&view=logs&jobId=dff6ff7b-316b-540a-5923-739df25f7012&j=dff6ff7b-316b-540a-5923-739df25f7012&t=2582809e-c3dc-5a5f-d883-fd3c8f9139aa

