### PR TITLE
Add mesh reconstruction command for curving/uncurving

### DIFF
--- a/src/io4dolfinx/__init__.py
+++ b/src/io4dolfinx/__init__.py
@@ -31,6 +31,7 @@ from .readers import (
     read_point_data,
 )
 from .snapshot import snapshot_checkpoint
+from .utils import reconstruct_mesh
 
 meta = metadata("io4dolfinx")
 __version__ = meta["Version"]
@@ -62,4 +63,5 @@ __all__ = [
     "get_backend",
     "write_cell_data",
     "write_point_data",
+    "reconstruct_mesh",
 ]

--- a/src/io4dolfinx/utils.py
+++ b/src/io4dolfinx/utils.py
@@ -249,12 +249,12 @@ def reconstruct_mesh(mesh: dolfinx.mesh.Mesh, coordinate_element_degree: int) ->
     )
     # Could use create_geometry here when things are fixed
     geom = dolfinx.mesh.Geometry(
-        mesh.geometry._cpp_object.__class__(
+        type(mesh.geometry._cpp_object)(
             geom_imap, geom_dofmap, coordinate_element._cpp_object, x, original_input_indices
         )
     )
 
     # Create new mesh
     new_top = mesh.topology
-    cpp_mesh = mesh._cpp_object.__class__(mesh.comm, new_top._cpp_object, geom._cpp_object)
+    cpp_mesh = type(mesh._cpp_object)(mesh.comm, new_top._cpp_object, geom._cpp_object)
     return dolfinx.mesh.Mesh(cpp_mesh, ufl.Mesh(new_c_el))

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,56 @@
+from mpi4py import MPI
+
+import dolfinx
+import numpy as np
+import pytest
+import ufl
+
+from io4dolfinx import reconstruct_mesh
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("degree", [2, 3])
+@pytest.mark.parametrize("R", [0.1, 1, 10])
+def test_curve_mesh(degree, dtype, R):
+    N = 8
+    mesh = dolfinx.mesh.create_rectangle(
+        MPI.COMM_WORLD,
+        [[-1, -1], [1, 1]],
+        [N, N],
+        diagonal=dolfinx.mesh.DiagonalType.crossed,
+        dtype=dtype,
+    )
+    org_area = dolfinx.fem.form(1 * ufl.dx(domain=mesh), dtype=dtype)
+
+    curved_mesh = reconstruct_mesh(mesh, degree)
+
+    def transform(x):
+        u = R * x[0] * np.sqrt(1 - (x[1] ** 2 / (2)))
+        v = R * x[1] * np.sqrt(1 - (x[0] ** 2 / (2)))
+        return np.asarray([u, v])
+
+    curved_mesh.geometry.x[:, : curved_mesh.geometry.dim] = transform(curved_mesh.geometry.x.T).T
+
+    area = dolfinx.fem.form(1 * ufl.dx(domain=curved_mesh), dtype=dtype)
+    circumference = dolfinx.fem.form(1 * ufl.ds(domain=curved_mesh), dtype=dtype)
+
+    computed_area = curved_mesh.comm.allreduce(dolfinx.fem.assemble_scalar(area), op=MPI.SUM)
+    computed_circumference = curved_mesh.comm.allreduce(
+        dolfinx.fem.assemble_scalar(circumference), op=MPI.SUM
+    )
+
+    tol = 10 * np.finfo(dtype).eps
+    assert np.isclose(computed_area, np.pi * R**2, atol=tol)
+    assert np.isclose(computed_circumference, 2 * np.pi * R, atol=tol)
+
+    linear_mesh = reconstruct_mesh(curved_mesh, 1)
+    linear_area = dolfinx.fem.form(1 * ufl.dx(domain=linear_mesh), dtype=dtype)
+
+    recovered_area = linear_mesh.comm.allreduce(
+        dolfinx.fem.assemble_scalar(linear_area), op=MPI.SUM
+    )
+
+    # Curve original mesh
+    mesh.geometry.x[:, : mesh.geometry.dim] = transform(mesh.geometry.x.T).T
+    ref_area = mesh.comm.allreduce(dolfinx.fem.assemble_scalar(org_area), op=MPI.SUM)
+    assert np.isclose(recovered_area, ref_area, atol=tol)


### PR DESCRIPTION
Make it possible to reconstruct mesh with new coordinate element degree.

Relevant for #23 and reading in other higher order function data that is really on linear meshes, where one would:
1. Read in "curved" mesh
2. Read in "curved" point data
3. Reconstruct linear mesh
4. Interpolate curved data onto linear mesh.