### PR TITLE
Do not force legacy h5 to have suffix .h5

### DIFF
--- a/src/io4dolfinx/readers.py
+++ b/src/io4dolfinx/readers.py
@@ -240,7 +240,7 @@ def read_function_from_legacy_h5(
     """
 
     # Make sure we use the HDF5File and check that the file is present
-    filename = pathlib.Path(filename).with_suffix(".h5")
+    filename = pathlib.Path(filename)
     if not filename.is_file():
         raise FileNotFoundError(f"File {filename} does not exist")
 

--- a/src/io4dolfinx/readers.py
+++ b/src/io4dolfinx/readers.py
@@ -241,6 +241,8 @@ def read_function_from_legacy_h5(
 
     # Make sure we use the HDF5File and check that the file is present
     filename = pathlib.Path(filename)
+    if filename.suffix == ".xdmf":
+        filename = filename.with_suffix(".h5")
     if not filename.is_file():
         raise FileNotFoundError(f"File {filename} does not exist")
 


### PR DESCRIPTION
Sometimes people use `.hdf`, in which case we would need to change the file before reading it which is a bit unnecessary. 

However if people pass in `.xdmf`, then change the filename to `.h5`