### PR TITLE
Add pyvista to docs dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ docs = [
     "ipykernel<7.0.0",     # Note: Remove once https://github.com/ipython/ipykernel/issues/1450 is in a release
     "sphinx-codeautolink",
     "io4dolfinx[h5py]",
+    "io4dolfinx[pyvista]",
     "sphinx_external_toc<1.1.0",
 ]
 all = ["io4dolfinx[test,dev,docs]"]


### PR DESCRIPTION
API docs are failing due to missing pyvista